### PR TITLE
Add Whitelist and Blacklist features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# Discord Bot Token File
-token
+# Discord Bot Config File
+config
 
 # Compiled class file
 *.class

--- a/README.md
+++ b/README.md
@@ -17,10 +17,22 @@ Here's how set up IntelliJ to be able to test run your code:
 1. Click on the combo box in the top right of the window, next to the debugging tools.
 2. Select edit configureations
 3. Click on the plus sign in the top left and then click on gradle
-4. Click on the folder button that is next to the textbox labeled Gradle Project, select the option that's the same as the project name.
+4. Click on the folder button that is next to the textbox labeled
+Gradle Project, select the option that's the same as the project name.
 5. In the textbox labeled "tasks" type the word "run" into it.
 6. Click on "Apply" and you're done!
 
 #Where should I go to learn how to use the JDA library?
 Use the link below. Almost all java documentation is in this format, so become fast friends with it!
+
 https://ci.dv8tion.net/job/JDA/javadoc/index.html
+
+#How to construct your 'config' file
+The first line should be the discord bot token.
+
+The second, optional line should be an User ID for the user
+whitelisting dev feature. You can get a User ID from the discord
+client by right clicking on a person's icon after enabling dev-tools
+in your discord options. This feature will make the bot only respond
+to you. It's perfect for testing out a dev version of the bot without
+interfearing with the live version!

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Use the link below. Almost all java documentation is in this format, so become f
 
 https://ci.dv8tion.net/job/JDA/javadoc/index.html
 
-#How to construct your 'config' file
+# How to construct your 'config' file
 The first line should be the discord bot token.
 
 The second, optional line should be an User ID for the user

--- a/src/main/java/com/fsucsc/discordbot/Bot.java
+++ b/src/main/java/com/fsucsc/discordbot/Bot.java
@@ -12,20 +12,22 @@ import java.util.Scanner;
 
 public class Bot {
 	public static void main (String[] args) {
-		String token = null;
 		try {
-			Scanner scan = new Scanner(new File("token"));
-			token = scan.nextLine();
+			Scanner scan = new Scanner(new File("config"));
+			DisConfig.token = scan.nextLine();
+			if (scan.hasNextLine()) {
+				DisConfig.whitelistedUser = scan.nextLine();
+			}
 		}
 		catch (FileNotFoundException | NoSuchElementException e) {
-			System.out.println("Error opening and reading token file.");
+			System.out.println("Error opening and reading config file.");
 			System.out.println("Are you sure it exists and contains the token for the discord bot?");
-			//NOTE(Michael): when working on the project, the 'token' file should be placed at the root of the repo
+			//NOTE(Michael): when working on the project, the 'config' file should be placed at the root of the repo
 			System.exit(-1);
 		}
 
 		try {
-			JDA jda = new JDABuilder(AccountType.BOT).setToken(token).addEventListeners(new CommandListener()).build();
+			JDA jda = new JDABuilder(AccountType.BOT).setToken(DisConfig.token).addEventListeners(new CommandListener()).build();
 		}
 		catch (LoginException | IllegalArgumentException e) {
 			System.out.println("Failed to Log in");

--- a/src/main/java/com/fsucsc/discordbot/Bot.java
+++ b/src/main/java/com/fsucsc/discordbot/Bot.java
@@ -17,6 +17,8 @@ public class Bot {
 			DisConfig.token = scan.nextLine();
 			if (scan.hasNextLine()) {
 				DisConfig.whitelistedUser = scan.nextLine();
+			} else {
+				DisConfig.whitelistedUser = null;
 			}
 		}
 		catch (FileNotFoundException | NoSuchElementException e) {

--- a/src/main/java/com/fsucsc/discordbot/Bot.java
+++ b/src/main/java/com/fsucsc/discordbot/Bot.java
@@ -27,7 +27,7 @@ public class Bot {
 		}
 
 		try {
-			JDA jda = new JDABuilder(AccountType.BOT).setToken(DisConfig.token).addEventListeners(new CommandListener()).build();
+			 new JDABuilder(AccountType.BOT).setToken(DisConfig.token).addEventListeners(new CommandListener()).build();
 		}
 		catch (LoginException | IllegalArgumentException e) {
 			System.out.println("Failed to Log in");

--- a/src/main/java/com/fsucsc/discordbot/CommandListener.java
+++ b/src/main/java/com/fsucsc/discordbot/CommandListener.java
@@ -10,6 +10,12 @@ public class CommandListener extends ListenerAdapter {
 		Message msg = e.getChannel().retrieveMessageById(e.getMessageId()).complete ();
 		String rawMsg = msg.getContentRaw();
 
+		if (DisConfig.whitelistedUser != null) {
+			if (!msg.getAuthor().getId().equals(DisConfig.whitelistedUser)) {
+				return;
+			}
+		}
+
 		if (rawMsg.startsWith("!ping")) {
 				msg.getChannel().sendMessage("Pong!").queue ();
 		}

--- a/src/main/java/com/fsucsc/discordbot/CommandListener.java
+++ b/src/main/java/com/fsucsc/discordbot/CommandListener.java
@@ -7,8 +7,8 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
 public class CommandListener extends ListenerAdapter {
 	//NOTE(Michael): we use onGenericMessage to allow for command testing in PMs.
-	public void onGenericMessage (GenericMessageEvent e) {
-		Message msg = e.getChannel().retrieveMessageById(e.getMessageId()).complete ();
+	public void onGenericMessage (GenericMessageEvent event) {
+		Message msg = event.getChannel().retrieveMessageById(event.getMessageId()).complete ();
 		String rawMsg = msg.getContentRaw();
 
 		//IMPORTANT(Michael): The ordering here is perticular to evoke a certain behaivor.
@@ -29,13 +29,25 @@ public class CommandListener extends ListenerAdapter {
 		}
 
 		if (rawMsg.startsWith("!blacklist")) {
-			rawMsg = rawMsg.substring("!blacklist".length() + 1);
-			User usr = msg.getMentionedUsers().get(0);
-			if (rawMsg.startsWith ("add")) {
-				DisConfig.blackListedUsers.add (usr.getId());
+			boolean failed = false;
+			try {
+				rawMsg = rawMsg.substring("!blacklist".length() + 1);
+				User usr = msg.getMentionedUsers().get(0);
+				if (rawMsg.startsWith ("add")) {
+					DisConfig.blackListedUsers.add (usr.getId());
+				}
+				else if (rawMsg.startsWith ("remove")) {
+					DisConfig.blackListedUsers.remove (usr.getId());
+				}
+				else {
+					failed = true;
+				}
 			}
-			else if (rawMsg.startsWith ("remove")) {
-				DisConfig.blackListedUsers.remove (usr.getId());
+			catch (IndexOutOfBoundsException e) {
+				failed = true;
+			}
+			if (failed) {
+				msg.getChannel().sendMessage("Usage: `!blacklist <add|remove> <MentionedUser>`").queue();
 			}
 		}
 

--- a/src/main/java/com/fsucsc/discordbot/CommandListener.java
+++ b/src/main/java/com/fsucsc/discordbot/CommandListener.java
@@ -1,17 +1,46 @@
 package com.fsucsc.discordbot;
 
 import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.message.GenericMessageEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
 public class CommandListener extends ListenerAdapter {
-	//NOTE(Michael):we use onGenericMessage to allow for command testing in PMs.
+	//NOTE(Michael): we use onGenericMessage to allow for command testing in PMs.
 	public void onGenericMessage (GenericMessageEvent e) {
 		Message msg = e.getChannel().retrieveMessageById(e.getMessageId()).complete ();
 		String rawMsg = msg.getContentRaw();
 
+		//IMPORTANT(Michael): The ordering here is perticular to evoke a certain behaivor.
+		//If a whitelist exists, we enforce it first and formost. A whitelist should
+		//only exist in a dev build of the bot.
+		//Next, we want to process any !blacklist commands so that even if someone
+		//is blacklisted they can unblacklist themselves. Blacklisting is intended to help
+		//devs test out their changes by having the currently running version ignore them.
+		//After that, we enforce the blacklist, so that devs who are working on their own
+		//features won't interact with the current live version of the bot.
+		//And finally, after the blacklist has been enforced, we process the message for the
+		//rest of the commands.
+
 		if (DisConfig.whitelistedUser != null) {
 			if (!msg.getAuthor().getId().equals(DisConfig.whitelistedUser)) {
+				return;
+			}
+		}
+
+		if (rawMsg.startsWith("!blacklist")) {
+			rawMsg = rawMsg.substring("!blacklist".length() + 1);
+			User usr = msg.getMentionedUsers().get(0);
+			if (rawMsg.startsWith ("add")) {
+				DisConfig.blackListedUsers.add (usr.getId());
+			}
+			else if (rawMsg.startsWith ("remove")) {
+				DisConfig.blackListedUsers.remove (usr.getId());
+			}
+		}
+
+		for (String id : DisConfig.blackListedUsers) {
+			if (msg.getAuthor().getId().equals(id)) {
 				return;
 			}
 		}

--- a/src/main/java/com/fsucsc/discordbot/DisConfig.java
+++ b/src/main/java/com/fsucsc/discordbot/DisConfig.java
@@ -1,6 +1,10 @@
 package com.fsucsc.discordbot;
 
+import java.util.List;
+import java.util.ArrayList;
+
 public final class DisConfig {
 	static String token = null;
 	static String whitelistedUser = null;
+	static List<String> blackListedUsers = new ArrayList<>();
 }

--- a/src/main/java/com/fsucsc/discordbot/DisConfig.java
+++ b/src/main/java/com/fsucsc/discordbot/DisConfig.java
@@ -1,0 +1,6 @@
+package com.fsucsc.discordbot;
+
+public final class DisConfig {
+	static String token = null;
+	static String whitelistedUser = null;
+}


### PR DESCRIPTION
These features are intended to help assist devs test their current build of the bot without interfering with the public facing live version of the bot or another developer who is currently testing their version of the bot.

The Blacklist command is intended to be used on the live public facing version of the bot. Though `!blacklist add` devs can ensure that when they send a command the live public facing bot will not respond. When a dev is done working, and would like for the live public facing version to respond to them again, they can issue a `!blacklist remove`. No matter if one is on the blacklist, the bot will always process `!blacklist` commands.

The Whitelist feature is provided via an extension of the token loading system. On startup, the bot will load it's token from a file named "config" that is in the same directory as the bot's executable. If a userID is provided on the line after the token, then the bot will only respond to that user period. (A userID can be produced by enabling discord's own devtools and right clicking one's name in the chat area.) This feature is intended to allow devs to limit their development version of the bot to only respond to them. That way, when you're testing your dev version of the bot, it will not interfere with the public facing live version!